### PR TITLE
Update vite and vite-plugin-solid to fix Solid Router

### DIFF
--- a/frontend/package.tmpl.json
+++ b/frontend/package.tmpl.json
@@ -10,8 +10,8 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "vite": "^3.0.9",
-    "vite-plugin-solid": "^2.3.0"
+    "vite": "^5.2.10",
+    "vite-plugin-solid": "^2.10.2"
   },
   "dependencies": {
     "solid-js": "^1.5.1"


### PR DESCRIPTION
Solid router does not work on the version of vite which is currently in the package.json.
The issue: solidjs/solid-router#165
I've tested a simple router setup, and it is now functional.

vite: 3.0.9 -> 5.2.10 
vite-plugin-solid: 2.3.0 -> 2.10.2
(Both are the latest versions as of making this PR)



